### PR TITLE
set html, not append

### DIFF
--- a/client/code.js
+++ b/client/code.js
@@ -15,7 +15,7 @@ async function emit($item, item) {
 
   HighlightJS = (await import('https://cdn.jsdelivr.net/npm/highlight.js@11.7.0/+esm')).HighlightJS
 
-  $item.append(`<pre class='hljs'><code class='hljs'>${HighlightJS.highlightAuto(item.text).value}</code></pre>`)
+  $item.html(`<pre class='hljs'><code class='hljs'>${HighlightJS.highlightAuto(item.text).value}</code></pre>`)
 
 
 }


### PR DESCRIPTION
Plugin content was duplicating each time emit fired. Replace `append()` with `html()`