### PR TITLE
add language field for code coloring

### DIFF
--- a/client/code.js
+++ b/client/code.js
@@ -14,8 +14,11 @@ async function emit($item, item) {
   }
 
   window.HighlightJS = (await import('https://cdn.jsdelivr.net/npm/highlight.js@11/+esm')).HighlightJS
-
-  $item.html(`<pre class='hljs'><code class='hljs'>${HighlightJS.highlightAuto(item.text).value}</code></pre>`)
+  const show = code => $item.html(`<pre class='hljs'><code class='hljs'>${code}</code></pre>`)
+  if('language' in item)
+    show(HighlightJS.highlight(item.text,{language:item.language}).value)
+  else
+    show(HighlightJS.highlightAuto(item.text).value)
 }
 
 function bind($item, item) {


### PR DESCRIPTION
I have code in the works to include a "language": "javascript" parameter to the page json for Code plugin items. Without this the code coloring is haphazard. With it much better. I am considering how the normal text editor might support this. 